### PR TITLE
fix: exclude opus-java dependency from jda-ktx & discord-webhooks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,12 @@ dependencies {
     jij("net.dv8tion:JDA:5.0.0-beta.24") {
         exclude(module = "opus-java")
     }
-    jij("club.minnced:jda-ktx:0.11.0-beta.20")
-    jij("club.minnced:discord-webhooks:0.8.4")
+    jij("club.minnced:jda-ktx:0.11.0-beta.20") {
+        exclude(module = "opus-java")
+    }
+    jij("club.minnced:discord-webhooks:0.8.4") {
+        exclude(module = "opus-java")
+    }
 }
 
 configurations {


### PR DESCRIPTION
This makes the mod not depend on JNA 4, which means mods will stop complaining about not being able to load native libraries.