### PR TITLE
Port to 1.21.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     }
 
     // discord
-    jij("net.dv8tion:JDA:5.6.1") {
+    jij("net.dv8tion:JDA:6.1.3") {
         exclude(module = "slf4j-api")
         exclude(group = "org.jetbrains.kotlin")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,8 @@ import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
 
 plugins {
-    kotlin("jvm") version "2.2.10"
-    id("fabric-loom") version "1.11-SNAPSHOT"
+    kotlin("jvm") version "2.2.21"
+    id("fabric-loom") version "1.14-SNAPSHOT"
 }
 
 loom {
@@ -26,13 +26,13 @@ repositories {
 }
 
 dependencies {
-    minecraft("com.mojang:minecraft:1.21.8")
+    minecraft("com.mojang:minecraft:1.21.11")
     mappings(loom.layered {
         officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-1.21.8:2025.07.20@zip")
+        //parchment("org.parchmentmc.data:parchment-1.21.8:2025.07.20@zip")
     })
-    modImplementation("net.fabricmc:fabric-loader:0.17.2")
-    modImplementation("net.fabricmc:fabric-language-kotlin:1.13.5+kotlin.2.2.10")
+    modImplementation("net.fabricmc:fabric-loader:0.18.2")
+    modImplementation("net.fabricmc:fabric-language-kotlin:1.13.7+kotlin.2.2.21")
 
     // config
     jij("org.spongepowered:configurate-core:4.2.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionSha256Sum=72f44c9f8ebcb1af43838f45ee5c4aa9c5444898b3468ab3f4af7b6076c5bc3f
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/dev/optimistic/decentdiscordbridge/mixin/PlayerListMixin.java
+++ b/src/main/java/dev/optimistic/decentdiscordbridge/mixin/PlayerListMixin.java
@@ -29,7 +29,7 @@ public abstract class PlayerListMixin {
     @Inject(method = "placeNewPlayer", at = @At("HEAD"))
     private void onPlayerLogin(Connection connection, ServerPlayer player, CommonListenerCookie cookie, CallbackInfo ci) {
         final GameProfile profile = player.getGameProfile();
-        ((CachedAvatarUrlDuck) profile).calculateAvatarUrl();
+        ((CachedAvatarUrlDuck) (Object) profile).calculateAvatarUrl();
     }
 
     @Inject(method = "broadcastChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Ljava/util/function/Predicate;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/network/chat/ChatType$Bound;)V", at = @At("TAIL"))

--- a/src/main/java/dev/optimistic/decentdiscordbridge/mixin/ServerPlayerMixin.java
+++ b/src/main/java/dev/optimistic/decentdiscordbridge/mixin/ServerPlayerMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.Mixin;
 public abstract class ServerPlayerMixin implements CachedAvatarUrlDuck {
     @Override
     public String getAvatarUrl() {
-        return ((CachedAvatarUrlDuck)
+        return ((CachedAvatarUrlDuck) (Object)
                 (((ServerPlayer) (Object) this)
                         .getGameProfile()))
                 .getAvatarUrl();

--- a/src/main/kotlin/dev/optimistic/decentdiscordbridge/bridge/impl/DiscordOutput.kt
+++ b/src/main/kotlin/dev/optimistic/decentdiscordbridge/bridge/impl/DiscordOutput.kt
@@ -8,6 +8,7 @@ import net.minecraft.commands.CommandSourceStack
 import net.minecraft.network.chat.Component
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.level.ServerLevel
+import net.minecraft.server.permissions.LevelBasedPermissionSet
 import net.minecraft.world.phys.Vec2
 import net.minecraft.world.phys.Vec3
 
@@ -35,10 +36,10 @@ class DiscordOutput(val message: Message, val user: User) : CommandSource {
 
         return CommandSourceStack(
             this,
-            Vec3.atLowerCornerOf(level.sharedSpawnPos),
+            Vec3.atLowerCornerOf(level.respawnData.pos()),
             Vec2.ZERO,
             level,
-            0,
+            LevelBasedPermissionSet.NO_PERMISSIONS,
             user.effectiveName,
             Component.literal(user.effectiveName),
             server,

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,10 +18,10 @@
     "decent-discord-bridge.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.11",
-    "minecraft": "~1.21.8",
+    "fabricloader": ">=0.17.3",
+    "minecraft": "1.21.11",
     "java": ">=21",
-    "fabric-language-kotlin": ">=1.13.5+kotlin.2.2.10"
+    "fabric-language-kotlin": ">=1.13.7+kotlin.2.2.21"
   },
   "jars": ${jars}
 }


### PR DESCRIPTION
I think the `(Object)` casts are required now since loom no longer applies the mixin annotation processor...