### PR TITLE
Don't compress JIJ deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ tasks {
             val fileOutputStream = BufferedOutputStream(Files.newOutputStream(path))
             val jarOutputStream = JarOutputStream(fileOutputStream)
             var entry = inputStream.nextJarEntry
+            jarOutputStream.setLevel(0)
 
             while (entry != null) {
                 jarOutputStream.putNextEntry(entry as ZipEntry)


### PR DESCRIPTION
Brings the jar size further down, this time to ~6.5MB